### PR TITLE
Improve PPO agent action scaling

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -26,5 +26,5 @@ class RolloutBuffer:
             'log_probs': torch.tensor(self.log_probs, dtype=torch.float32, device=device),
             'rewards': torch.tensor(self.rewards, dtype=torch.float32, device=device),
             'dones': torch.tensor(self.dones, dtype=torch.float32, device=device),
-            'state_values': torch.cat(self.state_values).to(device),
+            'state_values': torch.stack(self.state_values).to(device),
         }

--- a/simulator.py
+++ b/simulator.py
@@ -28,8 +28,7 @@ class PPOTrainerSimulator:
             state = self.state_vector()
             state_tensor = torch.tensor(state, dtype=torch.float32).unsqueeze(0).to(self.ppo_agent.device)
 
-            action, log_prob, value = self.ppo_agent.policy.act(state_tensor)
-            action = float(np.clip(action, self.action_low, self.action_high))
+            action, log_prob, value = self.ppo_agent.act(state_tensor)
 
             user_action = self.user.respond(action)
             compliance = self.user.compliance_prob(action)


### PR DESCRIPTION
## Summary
- add action range handling in `PPOAgent`
- implement `act` at the agent level with tanh-squashed actions
- adjust update step to evaluate log probabilities properly
- fix rollout buffer to stack scalar values
- call `ppo_agent.act` from simulator

## Testing
- `python3 main.py >/tmp/run.log && tail -n 20 /tmp/run.log`

------
https://chatgpt.com/codex/tasks/task_b_68844778ad688323b2e4b2b1eb415c60